### PR TITLE
Feature/api

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,8 +132,6 @@ GEM
     mini_magick (4.11.0)
     mini_mime (1.1.2)
     minitest (5.16.3)
-    momentjs-rails (2.29.4.1)
-      railties (>= 3.1)
     msgpack (1.5.6)
     net-imap (0.2.3)
       digest

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,0 +1,2 @@
+class Api::V1::BaseController < ApplicationController
+end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,13 +1,27 @@
 class Api::V1::BaseController < ApplicationController
+  before_action :check_max_api_calls
   before_action :authorize
+  after_action :generate_api_call_log
 
-  def authorize
+  private def authorize
     unless current_user
       render json: { error: t('invalid_auth_token') }, status: :unprocessable_entity
     end
   end
 
-  def current_user
+  private def current_user
     @logged_in_user ||= User.find_by(auth_token: params[:token])
+  end
+
+  private def check_max_api_calls
+    api_call_count = ApiRequestLogs.where(ip_address: request.remote_ip, created_at: 1.hour.ago..Time.now).count
+
+    if api_call_count >= QuoraClone::Api::V1::MAX_API_CALLS_PER_HOUR
+      render json: { error: t('too_many_api_calls') }, status: :unprocessable_entity
+    end
+  end
+
+  private def generate_api_call_log
+    ApiRequestLogs.create(ip_address: request.remote_ip, endpoint: request.url)
   end
 end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,2 +1,13 @@
 class Api::V1::BaseController < ApplicationController
+  before_action :authorize
+
+  def authorize
+    unless current_user
+      render json: { error: t('invalid_auth_token') }, status: :unprocessable_entity
+    end
+  end
+
+  def current_user
+    @logged_in_user ||= User.find_by(auth_token: params[:token])
+  end
 end

--- a/app/controllers/api/v1/topics_controller.rb
+++ b/app/controllers/api/v1/topics_controller.rb
@@ -1,0 +1,12 @@
+class Api::V1::TopicsController < Api::V1::BaseController
+  skip_before_action :authorize
+
+  def index
+    render json: Topic.all
+  end
+
+  def show
+    @questions = Question.tagged_with(params[:topic]).includes(:user, :rich_text_content, { sorted_answers: [:user, :rich_text_content] }, { sorted_comments: [:user] }, :topics).published_only.not_disabled.by_recently_created.limit(params[:x])
+    render json: @questions, each_serializer: QuestionSerializer, include: ['user', 'answers.user', 'answers.comments.user', 'comments.user']
+  end
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::UsersController < Api::V1::BaseController
+  def feed
+    @questions = Question.tagged_with(current_user.topic_list).includes(:user, :rich_text_content, { sorted_answers: [:user, :rich_text_content] }, { sorted_comments: [:user] }, :topics).published_only.not_disabled.by_recently_created
+    render json: @questions, each_serializer: QuestionSerializer, include: ['user', 'answers.user', 'answers.comments.user', 'comments.user']
+  end
+end

--- a/app/models/api_request_logs.rb
+++ b/app/models/api_request_logs.rb
@@ -1,0 +1,3 @@
+class ApiRequestLogs < ApplicationRecord
+  validates :endpoint, :ip_address, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   before_create :generate_confirmation_token
   after_create_commit :send_verification_mail
   before_update :reward_verification_credits, if: :verified_at_changed?
-  before_update :generate_auth_token, if: :verified_at_previously_changed?
+  before_update :generate_auth_token, if: :verified_at_changed?
 
   enum role: {
     admin: 0,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   before_create :generate_confirmation_token
   after_create_commit :send_verification_mail
   before_update :reward_verification_credits, if: :verified_at_changed?
+  before_update :generate_auth_token, if: :verified_at_previously_changed?
 
   enum role: {
     admin: 0,
@@ -90,5 +91,9 @@ class User < ApplicationRecord
   private def reward_verification_credits
     self.credits += QuoraClone::Credits::SUCCESS_VERIFICATION_CREDITS
     credit_transactions.build({ value: QuoraClone::Credits::SUCCESS_VERIFICATION_CREDITS, entity: nil, reason: 'Verification Reward.', transaction_type: 'credit' })
+  end
+
+  private def generate_auth_token
+    self.auth_token = TokenHandler.generate_token
   end
 end

--- a/app/serializers/answer_serializer.rb
+++ b/app/serializers/answer_serializer.rb
@@ -1,0 +1,9 @@
+class AnswerSerializer < ActiveModel::Serializer
+  attributes :id, :content, :total_upvotes, :total_downvotes
+  belongs_to :user
+  has_many :comments
+
+  def content
+    object.content.body
+  end
+end

--- a/app/serializers/comment_serializer.rb
+++ b/app/serializers/comment_serializer.rb
@@ -1,0 +1,4 @@
+class CommentSerializer < ActiveModel::Serializer
+  attributes :id, :content, :total_upvotes, :total_downvotes
+  belongs_to :user
+end

--- a/app/serializers/question_serializer.rb
+++ b/app/serializers/question_serializer.rb
@@ -1,5 +1,5 @@
 class QuestionSerializer < ActiveModel::Serializer
-  attributes :id, :title, :total_upvotes, :total_downvotes, :permalink
+  attributes :id, :title, :total_upvotes, :total_downvotes, :permalink, :topic_list
   belongs_to :user
   has_many :answers
   has_many :comments

--- a/app/serializers/question_serializer.rb
+++ b/app/serializers/question_serializer.rb
@@ -1,0 +1,6 @@
+class QuestionSerializer < ActiveModel::Serializer
+  attributes :id, :title, :total_upvotes, :total_downvotes, :permalink
+  belongs_to :user
+  has_many :answers
+  has_many :comments
+end

--- a/app/serializers/topic_serializer.rb
+++ b/app/serializers/topic_serializer.rb
@@ -1,0 +1,3 @@
+class TopicSerializer < ActiveModel::Serializer
+  attributes :id, :name
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,3 @@
+class UserSerializer < ActiveModel::Serializer
+  attributes :id, :name, :username
+end

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -1,4 +1,4 @@
-<h1>WELCOME <%= current_user.name %></h1>
+<div class="page-heading">WELCOME <%= current_user.name %></div>
 
 <div class="profile">
   <%= image_tag user_profile_image_link(current_user), class: 'profile-img' %>
@@ -6,6 +6,7 @@
   <div>Name: <%= current_user.name %></div>
   <div>Username: <%= current_user.username %></div>
   <div>Email: <%= current_user.email %></div>
+  <div>Auth Token: <%= current_user.auth_token %></div>
   <div>Your Credits: <%= current_user.credits %></div>
   <%= link_to 'Your credits history', credit_transactions_user_path %>
   <%= link_to 'Buy more credits!', credit_packs_path %>

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -24,4 +24,10 @@ module QuoraClone
     MINIMUM_CREDITS_FOR_QUESTION = 1
     MINIMUM_VOTES_TO_REWARD_CREDITS = 1
   end
+
+  module Api
+    module V1
+      MAX_API_CALLS_PER_HOUR = 2
+    end
+  end
 end

--- a/config/locales/controllers/api/v1/base/en.yml
+++ b/config/locales/controllers/api/v1/base/en.yml
@@ -1,2 +1,3 @@
 en:
   invalid_auth_token: 'Your auth token is invalid.'
+  too_many_api_calls: 'Too many requests. Please try again later.'

--- a/config/locales/controllers/api/v1/base/en.yml
+++ b/config/locales/controllers/api/v1/base/en.yml
@@ -1,0 +1,2 @@
+en:
+  invalid_auth_token: 'Your auth token is invalid.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,4 +59,10 @@ Rails.application.routes.draw do
     post 'mark_sent'
     patch 'mark_all_read'
   end
+
+  namespace :api do
+    namespace :v1 do
+      resources :topics, only: [:index, :show], param: :topic
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
+      get 'feed', to: 'users#feed', format: true, constraints: { format: :json }
       resources :topics, only: [:index, :show], param: :topic
     end
   end

--- a/db/migrate/20220926105135_add_auth_token_to_users.rb
+++ b/db/migrate/20220926105135_add_auth_token_to_users.rb
@@ -1,0 +1,5 @@
+class AddAuthTokenToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :auth_token, :string
+  end
+end

--- a/db/migrate/20220926113443_create_api_request_logs.rb
+++ b/db/migrate/20220926113443_create_api_request_logs.rb
@@ -1,0 +1,9 @@
+class CreateApiRequestLogs < ActiveRecord::Migration[7.0]
+  def change
+    create_table :api_request_logs do |t|
+      t.string :endpoint
+      t.string :ip_address
+      t.timestamp :created_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_26_105135) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_26_113443) do
   create_table "abuse_reports", force: :cascade do |t|
     t.string "abuse_reportable_type", null: false
     t.integer "abuse_reportable_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_26_113443) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_26_105135) do
   create_table "abuse_reports", force: :cascade do |t|
     t.string "abuse_reportable_type", null: false
     t.integer "abuse_reportable_id", null: false

--- a/lib/tasks/user/generate_auth_tokens.rake
+++ b/lib/tasks/user/generate_auth_tokens.rake
@@ -1,0 +1,8 @@
+namespace :user do
+  desc 'Generate auth token for old verified users.'
+  task :generate_auth_tokens => [:environment] do
+    if users_updated = User.where(auth_token: nil).where.not(verified_at: nil).update(auth_token: TokenHandler.generate_token)
+      puts "Auth tokens generated for #{users_updated.size} users."
+    end
+  end
+end


### PR DESCRIPTION
* Public API for topics like /api/topics/ruby.json should return recent x questions with answers and comments etc.
   * Lets not use use to_json. Jbuilder
   * Don’t expose all field, only public fields 
* Private API my_feed like /api/feed.json?token=mytoken should return questions belongs to topics I follow, including comments and answers.
   * Make use of the user's auth token.
   * Auth token should be generated for users when they are verified
   * Rake task to generate auth token for existing users who are verified and don’t have auth token
   * User can see authtoken from his profile page
* Only x number of public api calls per hour per IP address